### PR TITLE
Fix exception while running under non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /LanguageTool-$VERSION
 
 ADD misc/start.sh /start.sh
 RUN chmod a+x /start.sh
+RUN mkdir /nonexistent && touch /nonexistent/.languagetool.cfg
 
 CMD [ "/start.sh" ]
 EXPOSE 8010


### PR DESCRIPTION
Empty file added, so java will not throw exception while running under non-privileged user. Fixes #7 