### PR TITLE
Revert "Update to 5.2.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Silvio Fricke <silvio.fricke@gmail.com>
 
 RUN apk add --no-cache libgomp gcompat libstdc++
 
-ENV VERSION 5.2.3
+ENV VERSION 5.2
 RUN wget https://www.languagetool.org/download/LanguageTool-$VERSION.zip && \
     unzip LanguageTool-$VERSION.zip && \
     rm LanguageTool-$VERSION.zip


### PR DESCRIPTION
This reverts commit b2579a13d69407b519083a7cd381e90bea55b4ff.

[I get a 404 file not found error for 5.2.3](https://languagetool.org/download/LanguageTool-5.2.3.zip)

It looks like 5.2.3 is an update only to the LibreOffice extension and not the standalone `*.zip` file.  If you look at the [available downloads](https://languagetool.org/download/), you can see there is a `LanguageTool-5.2.3.oxt` but the latest `*.zip` is `LanguageTool-5.2.zip`.

cc @matt08