### PR TITLE
Resolve Docker error: Minimum memoryswap limit…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ docker run --name languagetool \
                         --read-only \
                         --mount type=bind,src=/tmp/languagetool/tmp,dst=/tmp \
                         -p 127.0.0.1:8010:8010 \
-                        --memory 412m --memory-swap 200m \
+                        --memory 412m --memory-swap 500m \
                         -e EXTRAOPTIONS="-Xmx382M" \
                         silviof/docker-languagetool:latest
 ```


### PR DESCRIPTION
… should be larger than memory limit.

At least on macOS with Docker Desktop 3.3 and Docker Engine 20.10.5,
`docker run --help | grep 'memory-swap'` reports:
Swap limit equal to memory plus swap.

Accordingly, this patch resolves that error.

---

In any case, thanks for sharing this image :-)