### PR TITLE
Multiarch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Set environment variables
         run: |
           make envout >> ${GITHUB_ENV}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Set environment variables
         run: |
           make envout >> ${GITHUB_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:14-alpine
+FROM openjdk:16-slim-buster
 
 # see Makefile.version
 ARG VERSION
 
 MAINTAINER Silvio Fricke <silvio.fricke@gmail.com>
 
-RUN apk add --no-cache libgomp gcompat libstdc++
+RUN apt-get update && apt-get install -y wget unzip && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://www.languagetool.org/download/LanguageTool-$VERSION.zip && \
     unzip LanguageTool-$VERSION.zip && \

--- a/Makefile.version
+++ b/Makefile.version
@@ -1,3 +1,4 @@
 VERSION := 5.3
 BUILDARG_VERSION := --build-arg VERSION=$(VERSION)
 IMAGENAME := docker.io/silviof/docker-languagetool
+BUILDARG_PLATFORM := --platform linux/amd64,linux/arm64/v8


### PR DESCRIPTION
This PR adds support for arm64v8 by making a multiarch image.

To achieve this, the base image was changed to openjdk:16-slim-buster (which is a multiarch image with amd64 and arm64v8) and the default builder was replaced with buildx.

Because of some limitations the flow was changed a bit, too.

Now it will build the multiarch image withput an output (cache only).
Then it will build the amd64 version (out of the cache) with --load it will be exported to docker
After the tests it will rebuild the multiarch (out of the cache) and push it